### PR TITLE
feat: accept other types of input

### DIFF
--- a/API.md
+++ b/API.md
@@ -60,7 +60,7 @@ element.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of the once call. |
-| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>string</code> |  | A NodeList or array of elements. |
+| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements. |
 | [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
 **Example**  
@@ -92,7 +92,7 @@ element again.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of a once call. |
-| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
+| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
 | [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
 **Example**  

--- a/API.md
+++ b/API.md
@@ -42,6 +42,13 @@ Mark DOM elements as processed to prevent multiple initializations.
   elements.forEach(el => el.innerHTML = 'processed');
 </script>
 ```
+**Example** *(Using a single element as input)*  
+```js
+// once methods always return an array, to simplify the use with a single
+// element use destructuring or the shift method.
+const [myElement] = once('my-once-id', document.body);
+const myElement = once('my-once-id', document.body).shift();
+```
 <a name="once"></a>
 
 ## once(id, selector, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
@@ -73,14 +80,34 @@ const elements = once('my-once-id', '[data-myelement]');
 once('my-once-id', document.querySelectorAll('[data-myelement]'));
 // Array or Array-like of Element.
 once('my-once-id', jQuery('[data-myelement]'));
-// Single Element.
-once('my-once-id', document.querySelector('#some-id'));
-// Alias for document, the once will be applied to the <html> element.
-once('my-once-id', document);
 // A CSS selector without a context.
 once('my-once-id', '[data-myelement]');
 // A CSS selector with a context.
 once('my-once-id', '[data-myelement]', document.head);
+// Single Element.
+once('my-once-id', document.querySelector('#some-id'));
+// Using document. Warning, see below.
+once('my-once-id', document);
+```
+**Example** *(Using a single element)*  
+```js
+// Once always returns an array, event when passing a single element. Some
+// forms that can be used to keep code readable.
+// Destructuring:
+const [myElement] = once('my-once-id', document.body);
+// By changing the resulting array, es5 compatible.
+const myElement = once('my-once-id', document.body).shift();
+```
+**Example** *(Using document)*  
+```js
+// Using document, the once will be applied to the <html> element and
+// the <html> element will be returned.
+once('my-once-id', document); // Warning! return [document.documentElement].
+// Using document is supported as a type of global switch when the element
+// being processed is not important.
+if (once('my-global-id', document).shift()) {
+  // Process something else.
+}
 ```
 
 * [once(id, selector, [context])](#once) ⇒ <code>Array.&lt;Element&gt;</code>
@@ -115,14 +142,25 @@ const elements = once.remove('my-once-id', '[data-myelement]');
 once.remove('my-once-id', document.querySelectorAll('[data-myelement]'));
 // Array or Array-like of Element.
 once.remove('my-once-id', jQuery('[data-myelement]'));
-// Single Element.
-once.remove('my-once-id', document.querySelector('#some-id'));
-// Alias for document, the once will be applied to the <html> element.
-once.remove('my-once-id', document);
 // A CSS selector without a context.
 once.remove('my-once-id', '[data-myelement]');
 // A CSS selector with a context.
 once.remove('my-once-id', '[data-myelement]', document.head);
+// Single Element.
+once.remove('my-once-id', document.querySelector('#some-id'));
+// Using document. Warning, see below.
+once.remove('my-once-id', document);
+```
+**Example** *(Using document)*  
+```js
+// Using document, the once will be applied to the <html> element and
+// the <html> element will be returned.
+once.remove('my-once-id', document); // Warning! return [document.documentElement].
+// Using document is supported as a type of global switch when the element
+// being processed is not important.
+if (once.remove('my-global-id', document).shift()) {
+  // Unprocess something else.
+}
 ```
 <a name="once.filter"></a>
 

--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@
 ## Functions
 
 <dl>
-<dt><a href="#once">once(id, input, [context])</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
+<dt><a href="#once">once(id, selector, [context])</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
 <dd><p>Ensures a JavaScript callback is only executed once on a set of elements.</p>
 <p>Filters a NodeList or array of elements, removing those already processed
 by a callback with a given id.
@@ -27,24 +27,24 @@ Mark DOM elements as processed to prevent multiple initializations.
 **Example** *(Use as a module)*  
 ```js
 <script type="module">
-  import once from "https://unpkg.com/once-dom@latest/dist/once.esm.js";
-  const elements = once("my-id", document.querySelectorAll("div"));
+  import once from 'https://unpkg.com/once-dom@latest/dist/once.esm.js';
+  const elements = once('my-once-id', 'div');
   // Initialize elements.
-  elements.forEach(el => el.innerHTML = "processed");
+  elements.forEach(el => el.innerHTML = 'processed');
 </script>
 ```
 **Example** *(Use as a regular script)*  
 ```js
 <script src="https://unpkg.com/once-dom@latest/dist/once.min.js"></script>
 <script>
-  const elements = once("my-id", document.querySelectorAll("div"));
+  const elements = once('my-once-id', 'div');
   // Initialize elements.
-  elements.forEach(el => el.innerHTML = "processed");
+  elements.forEach(el => el.innerHTML = 'processed');
 </script>
 ```
 <a name="once"></a>
 
-## once(id, input, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
+## once(id, selector, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
 Ensures a JavaScript callback is only executed once on a set of elements.
 
 Filters a NodeList or array of elements, removing those already processed
@@ -60,25 +60,37 @@ element.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of the once call. |
-| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements. |
+| selector | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements. |
 | [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
-**Example**  
+**Example** *(Basic usage)*  
 ```js
-const elements = once(
-  'my-once-id',
-  document.querySelectorAll('[data-myelement]'),
-);
+const elements = once('my-once-id', '[data-myelement]');
+```
+**Example** *(Input parameters accepted)*  
+```js
+// NodeList.
+once('my-once-id', document.querySelectorAll('[data-myelement]'));
+// Array or Array-like of Element.
+once('my-once-id', jQuery('[data-myelement]'));
+// Single Element.
+once('my-once-id', document.querySelector('#some-id'));
+// Alias for document, the once will be applied to the <html> element.
+once('my-once-id', document);
+// A CSS selector without a context.
+once('my-once-id', '[data-myelement]');
+// A CSS selector with a context.
+once('my-once-id', '[data-myelement]', document.head);
 ```
 
-* [once(id, input, [context])](#once) ⇒ <code>Array.&lt;Element&gt;</code>
-    * [.remove(id, input, [context])](#once.remove) ⇒ <code>Array.&lt;Element&gt;</code>
+* [once(id, selector, [context])](#once) ⇒ <code>Array.&lt;Element&gt;</code>
+    * [.remove(id, selector, [context])](#once.remove) ⇒ <code>Array.&lt;Element&gt;</code>
     * [.filter(id, elements)](#once.filter) ⇒ <code>Array.&lt;Element&gt;</code>
     * [.find(id, [context])](#once.find) ⇒ <code>Array.&lt;Element&gt;</code>
 
 <a name="once.remove"></a>
 
-### once.remove(id, input, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
+### once.remove(id, selector, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
 Removes a once id from an element's data-drupal-once attribute value.
 
 If a once id is removed from an element's data-drupal-once attribute value,
@@ -88,19 +100,29 @@ element again.
 **Kind**: static method of [<code>once</code>](#once)  
 **Returns**: <code>Array.&lt;Element&gt;</code> - A filtered array of elements that had been processed by the provided id,
   and are now able to be processed again.  
+**Example&lt;caption&gt;basic**: usage</caption>
+const elements = once.remove('my-once-id', '[data-myelement]');  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of a once call. |
-| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
+| selector | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
 | [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
-**Example**  
+**Example** *(Input parameters accepted)*  
 ```js
-const removedOnceElements = once.remove(
-  'my-once-id',
-  document.querySelectorAll('[data-myelement]'),
-);
+// NodeList.
+once.remove('my-once-id', document.querySelectorAll('[data-myelement]'));
+// Array or Array-like of Element.
+once.remove('my-once-id', jQuery('[data-myelement]'));
+// Single Element.
+once.remove('my-once-id', document.querySelector('#some-id'));
+// Alias for document, the once will be applied to the <html> element.
+once.remove('my-once-id', document);
+// A CSS selector without a context.
+once.remove('my-once-id', '[data-myelement]');
+// A CSS selector with a context.
+once.remove('my-once-id', '[data-myelement]', document.head);
 ```
 <a name="once.filter"></a>
 
@@ -108,23 +130,25 @@ const removedOnceElements = once.remove(
 Finds elements that have been processed by a given once id.
 
 Filters a NodeList or array, returning an array of the elements already
-processed by the provided once id.
+processed by the provided once id. If a selector is needed use the [find](#once.find) method.
 
 **Kind**: static method of [<code>once</code>](#once)  
 **Returns**: <code>Array.&lt;Element&gt;</code> - A filtered array of elements that have already been processed by the
   provided once id.  
+**Example&lt;caption&gt;basic**: usage</caption>
+const filteredElements = once.filter('my-once-id', '[data-myelement]');  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | id | <code>string</code> | The id of the once call. |
 | elements | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> | A NodeList or array of elements to be searched. |
 
-**Example**  
+**Example** *(Input parameters accepted)*  
 ```js
-const filteredElements = once.filter(
-  'my-once-id',
-  document.querySelectorAll('[data-myelement]'),
-);
+// NodeList.
+once.filter('my-once-id', document.querySelectorAll('[data-myelement]'));
+// Array or Array-like of Element.
+once.filter('my-once-id', jQuery('[data-myelement]'));
 ```
 <a name="once.find"></a>
 
@@ -137,13 +161,18 @@ corresponding once id value.
 **Kind**: static method of [<code>once</code>](#once)  
 **Returns**: <code>Array.&lt;Element&gt;</code> - A filtered array of elements that have already been processed by the
   provided once id.  
+**Example&lt;caption&gt;basic**: usage</caption>
+const oncedElements = once.find('my-once-id');  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of the once call. |
 | [context] | <code>Element</code> | <code>document.documentElement</code> | Scope of the search for matching elements. |
 
-**Example**  
+**Example** *(Input parameters accepted)*  
 ```js
-const oncedElements = once.find('my-once-id');
+// Call without a context.
+once.find('my-once-id');
+// Call with a context.
+once.find('my-once-id', document.head);
 ```

--- a/API.md
+++ b/API.md
@@ -67,7 +67,7 @@ element.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of the once call. |
-| selector | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements. |
+| selector | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>string</code> |  | A NodeList or array of elements. |
 | [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
 **Example** *(Basic usage)*  
@@ -86,8 +86,6 @@ once('my-once-id', '[data-myelement]');
 once('my-once-id', '[data-myelement]', document.head);
 // Single Element.
 once('my-once-id', document.querySelector('#some-id'));
-// Using document. Warning, see below.
-once('my-once-id', document);
 ```
 **Example** *(Using a single element)*  
 ```js
@@ -97,17 +95,6 @@ once('my-once-id', document);
 const [myElement] = once('my-once-id', document.body);
 // By changing the resulting array, es5 compatible.
 const myElement = once('my-once-id', document.body).shift();
-```
-**Example** *(Using document)*  
-```js
-// Using document, the once will be applied to the <html> element and
-// the <html> element will be returned.
-once('my-once-id', document); // Warning! return [document.documentElement].
-// Using document is supported as a type of global switch when the element
-// being processed is not important.
-if (once('my-global-id', document).shift()) {
-  // Process something else.
-}
 ```
 
 * [once(id, selector, [context])](#once) ⇒ <code>Array.&lt;Element&gt;</code>
@@ -133,7 +120,7 @@ const elements = once.remove('my-once-id', '[data-myelement]');
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | id | <code>string</code> |  | The id of a once call. |
-| selector | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>document</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
+| selector | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
 | [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
 **Example** *(Input parameters accepted)*  
@@ -148,19 +135,6 @@ once.remove('my-once-id', '[data-myelement]');
 once.remove('my-once-id', '[data-myelement]', document.head);
 // Single Element.
 once.remove('my-once-id', document.querySelector('#some-id'));
-// Using document. Warning, see below.
-once.remove('my-once-id', document);
-```
-**Example** *(Using document)*  
-```js
-// Using document, the once will be applied to the <html> element and
-// the <html> element will be returned.
-once.remove('my-once-id', document); // Warning! return [document.documentElement].
-// Using document is supported as a type of global switch when the element
-// being processed is not important.
-if (once.remove('my-global-id', document).shift()) {
-  // Unprocess something else.
-}
 ```
 <a name="once.filter"></a>
 

--- a/API.md
+++ b/API.md
@@ -9,7 +9,7 @@
 ## Functions
 
 <dl>
-<dt><a href="#once">once(id, elements)</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
+<dt><a href="#once">once(id, input, [context])</a> ⇒ <code>Array.&lt;Element&gt;</code></dt>
 <dd><p>Ensures a JavaScript callback is only executed once on a set of elements.</p>
 <p>Filters a NodeList or array of elements, removing those already processed
 by a callback with a given id.
@@ -44,7 +44,7 @@ Mark DOM elements as processed to prevent multiple initializations.
 ```
 <a name="once"></a>
 
-## once(id, elements) ⇒ <code>Array.&lt;Element&gt;</code>
+## once(id, input, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
 Ensures a JavaScript callback is only executed once on a set of elements.
 
 Filters a NodeList or array of elements, removing those already processed
@@ -57,10 +57,11 @@ element.
 **Returns**: <code>Array.&lt;Element&gt;</code> - An array of elements that have not yet been processed by a once call
   with a given id.  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| id | <code>string</code> | The id of the once call. |
-| elements | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> | A NodeList or array of elements. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| id | <code>string</code> |  | The id of the once call. |
+| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>string</code> |  | A NodeList or array of elements. |
+| [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
 **Example**  
 ```js
@@ -70,14 +71,14 @@ const elements = once(
 );
 ```
 
-* [once(id, elements)](#once) ⇒ <code>Array.&lt;Element&gt;</code>
-    * [.remove(id, elements)](#once.remove) ⇒ <code>Array.&lt;Element&gt;</code>
+* [once(id, input, [context])](#once) ⇒ <code>Array.&lt;Element&gt;</code>
+    * [.remove(id, input, [context])](#once.remove) ⇒ <code>Array.&lt;Element&gt;</code>
     * [.filter(id, elements)](#once.filter) ⇒ <code>Array.&lt;Element&gt;</code>
     * [.find(id, [context])](#once.find) ⇒ <code>Array.&lt;Element&gt;</code>
 
 <a name="once.remove"></a>
 
-### once.remove(id, elements) ⇒ <code>Array.&lt;Element&gt;</code>
+### once.remove(id, input, [context]) ⇒ <code>Array.&lt;Element&gt;</code>
 Removes a once id from an element's data-drupal-once attribute value.
 
 If a once id is removed from an element's data-drupal-once attribute value,
@@ -88,10 +89,11 @@ element again.
 **Returns**: <code>Array.&lt;Element&gt;</code> - A filtered array of elements that had been processed by the provided id,
   and are now able to be processed again.  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| id | <code>string</code> | The id of a once call. |
-| elements | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> | A NodeList or array of elements to remove the once id from. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| id | <code>string</code> |  | The id of a once call. |
+| input | <code>NodeList</code> \| <code>Array.&lt;Element&gt;</code> \| <code>Element</code> \| <code>string</code> |  | A NodeList or array of elements to remove the once id from. |
+| [context] | <code>HTMLElement</code> | <code>document.documentElement</code> | An element to use as context for querySelectorAll. |
 
 **Example**  
 ```js

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ Select and filter DOM elements to process them only once.
 **Example** *(Use as a module)*
 ```html
 <script type="module">
-  import once from "https://unpkg.com/once-dom@latest/dist/once.esm.js";
-  const elements = once("my-id", document.querySelectorAll("div"));
+  import once from 'https://unpkg.com/once-dom@latest/dist/once.esm.js';
+  const elements = once('my-once-id', 'div');
   // Initialize elements.
-  elements.forEach(el => el.innerHTML = "processed");
+  elements.forEach(el => el.innerHTML = 'processed');
 </script>
 ```
 **Example** *(Use as a regular script)*
 ```html
 <script src="https://unpkg.com/once-dom@latest/dist/once.min.js"></script>
 <script>
-  const elements = once("my-id", document.querySelectorAll("div"));
+  const elements = once('my-once-id', 'div');
   // Initialize elements.
-  elements.forEach(el => el.innerHTML = "processed");
+  elements.forEach(el => el.innerHTML = 'processed');
 </script>
 ```
 

--- a/src/once.js
+++ b/src/once.js
@@ -65,6 +65,7 @@ const html = document.documentElement;
  *   Optional value for setAttribute.
  *
  * @return {string|undefined|null|boolean}
+ *   Result of the attribute method.
  */
 function attr(element, op, value) {
   const method = `${op}Attribute`;

--- a/src/once.js
+++ b/src/once.js
@@ -88,6 +88,34 @@ function checkElement(itemToCheck) {
 }
 
 /**
+ * Process arguments, query the DOM if necessary.
+ *
+ * @private
+ *
+ * @param {string} id
+ *   The id of the once call.
+ * @param {NodeList|Array.<Element>|Element|string} input
+ *   A NodeList or array of elements.
+ * @param {HTMLElement} [context=document.documentElement]
+ *   An element to use as context for querySelectorAll.
+ */
+function processArgs(id, input, context = document.documentElement) {
+  let elements = input;
+
+  // This is a selector, query the elements.
+  if (typeof input === 'string') {
+    checkElement(context);
+    elements = context.querySelectorAll(input);
+  }
+  // This is a single element.
+  if (input instanceof Element) {
+    elements = [input];
+  }
+
+  return [checkId(id), elements];
+}
+
+/**
  * A helper for applying DOM changes to a filtered set of elements.
  *
  * This makes it possible to filter items that are not instances of Element,
@@ -169,15 +197,17 @@ function updateAttribute({ value, add, remove }) {
  *
  * @param  {string} id
  *   The id of the once call.
- * @param  {NodeList|Array.<Element>} elements
+ * @param {NodeList|Array.<Element>|Element|string} input
  *   A NodeList or array of elements.
+ * @param {HTMLElement} [context=document.documentElement]
+ *   An element to use as context for querySelectorAll.
  *
  * @return {Array.<Element>}
  *   An array of elements that have not yet been processed by a once call
  *   with a given id.
  */
-function once(id, elements) {
-  const dataId = checkId(id);
+function once(id, input, context) {
+  const [dataId, elements] = processArgs(id, input, context);
   return filterAndModify(
     elements,
     `:not([${attrName}~="${dataId}"])`,
@@ -211,15 +241,17 @@ function once(id, elements) {
  *
  * @param  {string} id
  *   The id of a once call.
- * @param  {NodeList|Array.<Element>} elements
+ * @param  {NodeList|Array.<Element>|Element|string} input
  *   A NodeList or array of elements to remove the once id from.
+ * @param {HTMLElement} [context=document.documentElement]
+ *   An element to use as context for querySelectorAll.
  *
  * @return {Array.<Element>}
  *   A filtered array of elements that had been processed by the provided id,
  *   and are now able to be processed again.
  */
-once.remove = (id, elements) => {
-  const dataId = checkId(id);
+once.remove = (id, input, context) => {
+  const [dataId, elements] = processArgs(id, input, context);
   return filterAndModify(elements, `[${attrName}~="${dataId}"]`, element => {
     const value = updateAttribute({
       value: element.getAttribute(attrName),

--- a/src/once.js
+++ b/src/once.js
@@ -108,7 +108,7 @@ function checkElement(itemToCheck) {
  *
  * @param {string} id
  *   The id of the once call.
- * @param {NodeList|Array.<Element>|Element|document|string} selector
+ * @param {NodeList|Array.<Element>|Element|string} selector
  *   A NodeList or array of elements.
  * @param {HTMLElement} [context=document.documentElement]
  *   An element to use as context for querySelectorAll.
@@ -122,10 +122,6 @@ function processArgs(id, selector, context = html) {
   // This is a selector, query the elements.
   if (typeof selector === 'string' && checkElement(context)) {
     elements = context.querySelectorAll(selector);
-  }
-  // `document` object is not an Element, point to `<html>`.
-  else if (selector === document) {
-    elements = [html];
   }
   // This is a single element.
   else if (selector instanceof Element) {
@@ -222,8 +218,6 @@ function updateAttribute({ value, add, remove }) {
  * once('my-once-id', '[data-myelement]', document.head);
  * // Single Element.
  * once('my-once-id', document.querySelector('#some-id'));
- * // Using document. Warning, see below.
- * once('my-once-id', document);
  * @example <caption>Using a single element</caption>
  * // Once always returns an array, event when passing a single element. Some
  * // forms that can be used to keep code readable.
@@ -231,19 +225,10 @@ function updateAttribute({ value, add, remove }) {
  * const [myElement] = once('my-once-id', document.body);
  * // By changing the resulting array, es5 compatible.
  * const myElement = once('my-once-id', document.body).shift();
- * @example <caption>Using document</caption>
- * // Using document, the once will be applied to the <html> element and
- * // the <html> element will be returned.
- * once('my-once-id', document); // Warning! return [document.documentElement].
- * // Using document is supported as a type of global switch when the element
- * // being processed is not important.
- * if (once('my-global-id', document).shift()) {
- *   // Process something else.
- * }
  *
  * @param  {string} id
  *   The id of the once call.
- * @param {NodeList|Array.<Element>|Element|document|string} selector
+ * @param {NodeList|Array.<Element>|Element|string} selector
  *   A NodeList or array of elements.
  * @param {HTMLElement} [context=document.documentElement]
  *   An element to use as context for querySelectorAll.
@@ -292,21 +277,10 @@ function once(id, selector, context) {
  * once.remove('my-once-id', '[data-myelement]', document.head);
  * // Single Element.
  * once.remove('my-once-id', document.querySelector('#some-id'));
- * // Using document. Warning, see below.
- * once.remove('my-once-id', document);
- * @example <caption>Using document</caption>
- * // Using document, the once will be applied to the <html> element and
- * // the <html> element will be returned.
- * once.remove('my-once-id', document); // Warning! return [document.documentElement].
- * // Using document is supported as a type of global switch when the element
- * // being processed is not important.
- * if (once.remove('my-global-id', document).shift()) {
- *   // Unprocess something else.
- * }
  *
  * @param  {string} id
  *   The id of a once call.
- * @param  {NodeList|Array.<Element>|Element|document|string} selector
+ * @param  {NodeList|Array.<Element>|Element|string} selector
  *   A NodeList or array of elements to remove the once id from.
  * @param {HTMLElement} [context=document.documentElement]
  *   An element to use as context for querySelectorAll.

--- a/src/once.js
+++ b/src/once.js
@@ -18,6 +18,11 @@
  *   // Initialize elements.
  *   elements.forEach(el => el.innerHTML = 'processed');
  * </script>
+ * @example <caption>Using a single element as input</caption>
+ * // once methods always return an array, to simplify the use with a single
+ * // element use destructuring or the shift method.
+ * const [myElement] = once('my-once-id', document.body);
+ * const myElement = once('my-once-id', document.body).shift();
  */
 
 /**
@@ -212,14 +217,30 @@ function updateAttribute({ value, add, remove }) {
  * once('my-once-id', document.querySelectorAll('[data-myelement]'));
  * // Array or Array-like of Element.
  * once('my-once-id', jQuery('[data-myelement]'));
- * // Single Element.
- * once('my-once-id', document.querySelector('#some-id'));
- * // Alias for document, the once will be applied to the <html> element.
- * once('my-once-id', document);
  * // A CSS selector without a context.
  * once('my-once-id', '[data-myelement]');
  * // A CSS selector with a context.
  * once('my-once-id', '[data-myelement]', document.head);
+ * // Single Element.
+ * once('my-once-id', document.querySelector('#some-id'));
+ * // Using document. Warning, see below.
+ * once('my-once-id', document);
+ * @example <caption>Using a single element</caption>
+ * // Once always returns an array, event when passing a single element. Some
+ * // forms that can be used to keep code readable.
+ * // Destructuring:
+ * const [myElement] = once('my-once-id', document.body);
+ * // By changing the resulting array, es5 compatible.
+ * const myElement = once('my-once-id', document.body).shift();
+ * @example <caption>Using document</caption>
+ * // Using document, the once will be applied to the <html> element and
+ * // the <html> element will be returned.
+ * once('my-once-id', document); // Warning! return [document.documentElement].
+ * // Using document is supported as a type of global switch when the element
+ * // being processed is not important.
+ * if (once('my-global-id', document).shift()) {
+ *   // Process something else.
+ * }
  *
  * @param  {string} id
  *   The id of the once call.
@@ -266,14 +287,23 @@ function once(id, selector, context) {
  * once.remove('my-once-id', document.querySelectorAll('[data-myelement]'));
  * // Array or Array-like of Element.
  * once.remove('my-once-id', jQuery('[data-myelement]'));
- * // Single Element.
- * once.remove('my-once-id', document.querySelector('#some-id'));
- * // Alias for document, the once will be applied to the <html> element.
- * once.remove('my-once-id', document);
  * // A CSS selector without a context.
  * once.remove('my-once-id', '[data-myelement]');
  * // A CSS selector with a context.
  * once.remove('my-once-id', '[data-myelement]', document.head);
+ * // Single Element.
+ * once.remove('my-once-id', document.querySelector('#some-id'));
+ * // Using document. Warning, see below.
+ * once.remove('my-once-id', document);
+ * @example <caption>Using document</caption>
+ * // Using document, the once will be applied to the <html> element and
+ * // the <html> element will be returned.
+ * once.remove('my-once-id', document); // Warning! return [document.documentElement].
+ * // Using document is supported as a type of global switch when the element
+ * // being processed is not important.
+ * if (once.remove('my-global-id', document).shift()) {
+ *   // Unprocess something else.
+ * }
  *
  * @param  {string} id
  *   The id of a once call.

--- a/src/once.js
+++ b/src/once.js
@@ -120,8 +120,7 @@ function processArgs(id, selector, context = html) {
   let elements = selector;
 
   // This is a selector, query the elements.
-  if (typeof selector === 'string') {
-    checkElement(context);
+  if (typeof selector === 'string' && checkElement(context)) {
     elements = context.querySelectorAll(selector);
   }
   // `document` object is not an Element, point to `<html>`.

--- a/src/once.js
+++ b/src/once.js
@@ -39,6 +39,15 @@ const wsRE = /[\11\12\14\15\40]+/;
 const attrName = 'data-once';
 
 /**
+ * Shortcut to access the html element.
+ *
+ * @private
+ *
+ * @type {HTMLElement}
+ */
+const html = document.documentElement;
+
+/**
  * Verify the validity of the once id.
  *
  * @private
@@ -94,12 +103,12 @@ function checkElement(itemToCheck) {
  *
  * @param {string} id
  *   The id of the once call.
- * @param {NodeList|Array.<Element>|Element|string} input
+ * @param {NodeList|Array.<Element>|Element|document|string} input
  *   A NodeList or array of elements.
  * @param {HTMLElement} [context=document.documentElement]
  *   An element to use as context for querySelectorAll.
  */
-function processArgs(id, input, context = document.documentElement) {
+function processArgs(id, input, context = html) {
   let elements = input;
 
   // This is a selector, query the elements.
@@ -107,8 +116,12 @@ function processArgs(id, input, context = document.documentElement) {
     checkElement(context);
     elements = context.querySelectorAll(input);
   }
+  // `document` object is not an Element, point to `<html>`.
+  else if (input === document) {
+    elements = [html];
+  }
   // This is a single element.
-  if (input instanceof Element) {
+  else if (input instanceof Element) {
     elements = [input];
   }
 
@@ -197,7 +210,7 @@ function updateAttribute({ value, add, remove }) {
  *
  * @param  {string} id
  *   The id of the once call.
- * @param {NodeList|Array.<Element>|Element|string} input
+ * @param {NodeList|Array.<Element>|Element|document|string} input
  *   A NodeList or array of elements.
  * @param {HTMLElement} [context=document.documentElement]
  *   An element to use as context for querySelectorAll.
@@ -241,7 +254,7 @@ function once(id, input, context) {
  *
  * @param  {string} id
  *   The id of a once call.
- * @param  {NodeList|Array.<Element>|Element|string} input
+ * @param  {NodeList|Array.<Element>|Element|document|string} input
  *   A NodeList or array of elements to remove the once id from.
  * @param {HTMLElement} [context=document.documentElement]
  *   An element to use as context for querySelectorAll.
@@ -313,7 +326,7 @@ once.filter = (id, elements) => {
  *   A filtered array of elements that have already been processed by the
  *   provided once id.
  */
-once.find = (id, context = document.documentElement) => {
+once.find = (id, context = html) => {
   const dataId = checkId(id);
   return (
     checkElement(context) &&

--- a/src/once.js
+++ b/src/once.js
@@ -69,7 +69,7 @@ const html = document.documentElement;
  */
 function attr(element, op, value) {
   const method = `${op}Attribute`;
-  return method in element && element[method](...[attrName, value]);
+  return method in element && element[method](attrName, value);
 }
 
 /**

--- a/test/once.test.js
+++ b/test/once.test.js
@@ -138,7 +138,8 @@ describe('once', () => {
     // Check the return of the function.
     expect(once('test12', document))
       .to.be.a('array')
-      .with.lengthOf(1);
+      .with.lengthOf(1)
+      .deep.equal([html]);
 
     // Make sure the DOM has been updated properly.
     expect(html).to.have.attribute('data-once', 'test12');
@@ -146,7 +147,8 @@ describe('once', () => {
     // Check the return of the function.
     expect(once.remove('test12', document))
       .to.be.a('array')
-      .with.lengthOf(1);
+      .with.lengthOf(1)
+      .deep.equal([html]);
 
     // Make sure the DOM has been updated properly.
     expect(html).to.not.have.attribute('data-once');

--- a/test/once.test.js
+++ b/test/once.test.js
@@ -132,4 +132,23 @@ describe('once', () => {
     // Make sure the DOM has been updated properly.
     expect(span[0]).dom.to.equal('<span>test</span>');
   });
+
+  it('Use document as input for once and once.remove', () => {
+    const html = document.documentElement;
+    // Check the return of the function.
+    expect(once('test12', document))
+      .to.be.a('array')
+      .with.lengthOf(1);
+
+    // Make sure the DOM has been updated properly.
+    expect(html).to.have.attribute('data-once', 'test12');
+
+    // Check the return of the function.
+    expect(once.remove('test12', document))
+      .to.be.a('array')
+      .with.lengthOf(1);
+
+    // Make sure the DOM has been updated properly.
+    expect(html).to.not.have.attribute('data-once');
+  });
 });

--- a/test/once.test.js
+++ b/test/once.test.js
@@ -10,8 +10,8 @@ describe('once', () => {
   let span;
 
   beforeEach(() => {
-    document.body.innerHTML = '<p><span>test</span></p>';
-    span = document.querySelectorAll('span');
+    document.body.innerHTML = '<p><span>test</span></p><span></span>';
+    span = document.querySelectorAll('p span');
   });
 
   it('require ID to be a string', () => {
@@ -88,5 +88,48 @@ describe('once', () => {
     expect(once('test82', span)).to.have.lengthOf(1);
 
     expect(once.find('test81')).to.have.lengthOf(1);
+  });
+
+  it('Use a string input for once and once.remove no context', () => {
+    // Check the return of the function.
+    expect(once('test9', 'span'))
+      .to.be.a('array')
+      .with.lengthOf(2);
+
+    // Check the return of the function.
+    expect(once.remove('test9', 'span'))
+      .to.be.a('array')
+      .with.lengthOf(2);
+  });
+
+  it('Use a string input for once and once.remove with context', () => {
+    const context = document.querySelector('p');
+    // Check the return of the function.
+    expect(once('test10', 'span', context))
+      .to.be.a('array')
+      .with.lengthOf(1);
+
+    // Check the return of the function.
+    expect(once.remove('test10', 'span', context))
+      .to.be.a('array')
+      .with.lengthOf(1);
+  });
+
+  it('Use a single element input for once and once.remove', () => {
+    // Check the return of the function.
+    expect(once('test11', span[0]))
+      .to.be.a('array')
+      .with.lengthOf(1);
+
+    // Make sure the DOM has been updated properly.
+    expect(span[0]).dom.to.equal('<span data-once="test11">test</span>');
+
+    // Check the return of the function.
+    expect(once.remove('test11', span[0]))
+      .to.be.a('array')
+      .with.lengthOf(1);
+
+    // Make sure the DOM has been updated properly.
+    expect(span[0]).dom.to.equal('<span>test</span>');
   });
 });

--- a/test/once.test.js
+++ b/test/once.test.js
@@ -132,25 +132,4 @@ describe('once', () => {
     // Make sure the DOM has been updated properly.
     expect(span[0]).dom.to.equal('<span>test</span>');
   });
-
-  it('Use document as input for once and once.remove', () => {
-    const html = document.documentElement;
-    // Check the return of the function.
-    expect(once('test12', document))
-      .to.be.a('array')
-      .with.lengthOf(1)
-      .deep.equal([html]);
-
-    // Make sure the DOM has been updated properly.
-    expect(html).to.have.attribute('data-once', 'test12');
-
-    // Check the return of the function.
-    expect(once.remove('test12', document))
-      .to.be.a('array')
-      .with.lengthOf(1)
-      .deep.equal([html]);
-
-    // Make sure the DOM has been updated properly.
-    expect(html).to.not.have.attribute('data-once');
-  });
 });


### PR DESCRIPTION
Help reduce cruft in code using this library. It is now possible to use: 
```js
once('id', 'selector');
once('id', 'selector', context);
once('id', document.body);
once('id', document); // Will apply to document.documentElement
```

refs #2